### PR TITLE
Add AWS EC2 deployment scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "@aws-sdk/client-ec2": "^3.591.0",
+    "@aws-sdk/credential-provider-ini": "^3.591.0"
   }
 }

--- a/scripts/deployEc2.ts
+++ b/scripts/deployEc2.ts
@@ -1,0 +1,50 @@
+// Script to launch an EC2 instance, create AMI, and measure boot times
+import {
+  EC2Client,
+  RunInstancesCommand,
+  waitUntilInstanceStatusOk,
+  CreateImageCommand,
+  waitUntilImageAvailable,
+} from "@aws-sdk/client-ec2";
+import { fromIni } from "@aws-sdk/credential-provider-ini";
+import fs from "fs";
+
+const region = process.env.AWS_REGION || "us-east-1";
+const client = new EC2Client({ region, credentials: fromIni() });
+
+async function launchInstance(amiId: string, userData: string) {
+  const start = Date.now();
+  const run = await client.send(
+    new RunInstancesCommand({
+      ImageId: amiId,
+      InstanceType: "t2.micro",
+      MinCount: 1,
+      MaxCount: 1,
+      UserData: Buffer.from(userData).toString("base64"),
+    })
+  );
+  const instanceId = run.Instances?.[0].InstanceId as string;
+  await waitUntilInstanceStatusOk({ client, maxWaitTime: 300 }, { InstanceIds: [instanceId] });
+  const end = Date.now();
+  const boot = (end - start) / 1000;
+  console.log(`Instance ${instanceId} booted in ${boot} seconds`);
+  return instanceId;
+}
+
+async function createAmi(instanceId: string, name: string) {
+  const resp = await client.send(
+    new CreateImageCommand({ InstanceId: instanceId, Name: name })
+  );
+  const imageId = resp.ImageId as string;
+  await waitUntilImageAvailable({ client, maxWaitTime: 300 }, { ImageIds: [imageId] });
+  console.log(`AMI ${imageId} created`);
+  return imageId;
+}
+
+(async () => {
+  const userData = fs.readFileSync("scripts/user-data.sh", "utf8");
+  const baseAmi = "ami-051f7e7f6c2f40dc1"; // Amazon Linux 2 AMI
+  const instanceId = await launchInstance(baseAmi, userData);
+  const amiId = await createAmi(instanceId, "app-snapshot");
+  await launchInstance(amiId, "");
+})();

--- a/scripts/user-data.sh
+++ b/scripts/user-data.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Install Node.js and git
+sudo yum update -y
+sudo yum install -y git
+curl -sL https://rpm.nodesource.com/setup_16.x | sudo bash -
+sudo yum install -y nodejs
+
+# Clone application repository (replace <repo-url> with actual repo)
+REPO_URL="https://example.com/hw1.git"
+APP_DIR="/home/ec2-user/app"
+
+if [ ! -d "$APP_DIR" ]; then
+  git clone $REPO_URL $APP_DIR
+  cd $APP_DIR
+  npm install
+  npm run build || true
+fi
+
+node dist/server.js > app.log 2>&1 &
+


### PR DESCRIPTION
## Summary
- add TypeScript script to launch EC2 instances, create AMI and measure boot times
- provide sample user-data script for installing Node and deploying HW1
- include AWS SDK dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853b9cf8f708330a876d836234aa5af